### PR TITLE
Use mkdir -p when creating the build dir

### DIFF
--- a/vagrant/install.sh
+++ b/vagrant/install.sh
@@ -11,4 +11,4 @@ sudo apt-get -y dist-upgrade
 sudo apt-get install -y git unzip htop memcached
 
 cd ~
-mkdir build
+mkdir -p build


### PR DESCRIPTION
This is to allow install.sh to exit without error if the build subdir already exists.

I hit this error when running 'provision':

```==> default: mkdir:
==> default: cannot create directory ‘build’
==> default: : File exists
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

and making the mkdir not fail gets past it (the initial `vagrant up` failed due to an OOM error).